### PR TITLE
Fix stage points lookup

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -274,12 +274,17 @@ document.addEventListener('DOMContentLoaded', () => {
     window.gameState = gameState;
     // ===== Helpers for stage points & scoring policy =====
  function updateStagePoints(quizId, score, total){
-  const el = document.querySelector(`[data-stage-points="${quizId}"]`);
-  if (!el) return;
-  const progress = JSON.parse(localStorage.getItem('iugGameProgress')||'{}');
-  const best = progress.bestScores?.[quizId] || 0;
-  el.textContent = `✔ ${best}/${total}`;
-}
+     const el = document.querySelector(`[data-stage-points="${quizId}"]`);
+     if (!el) return;
+     // Read the player's best score from stored attempts instead of the
+     // non-existent `bestScores` object. Fall back to the provided arguments
+     // when available.
+     const progress = JSON.parse(localStorage.getItem('iugGameProgress') || '{}');
+     const attempt = progress.attempts?.[quizId] || {};
+     const best = attempt.bestScore ?? score ?? 0;
+     const totalQuestions = attempt.total ?? total ?? 0;
+     el.textContent = `✔ ${best}/${totalQuestions}`;
+ }
 
     window.updateStagePoints = updateStagePoints;
 


### PR DESCRIPTION
## Summary
- correctly compute stage points using stored attempt data
- fallback to passed-in values when localStorage data unavailable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c7d413b4008320b4b27951c25670af